### PR TITLE
Change method properly display the time to clock out

### DIFF
--- a/pontomais-saida.js
+++ b/pontomais-saida.js
@@ -58,5 +58,5 @@ function calculateClockOut(clocks) {
 function displayClockOut(outDate) {
     let clockOutElement = document.querySelector('table tr td[aria-colindex="9"] div > div');
     let clockOutText = `${outDate.getHours()}:${outDate.getMinutes()}`;
-    clockOutElement.setHTML(`<span style="color:red">🌇 ${clockOutText}</span>`);
+    clockOutElement.innerHTML = `<span style="color:red">🌇 ${clockOutText}</span>`;
 }


### PR DESCRIPTION
Not sure what happened, but setHTML doesn't work for me anymore.
I'm using Chrome Version 119.0.6045.106